### PR TITLE
Changed week descriptors to match meetup_test.py

### DIFF
--- a/exercises/practice/meetup/.docs/instructions.md
+++ b/exercises/practice/meetup/.docs/instructions.md
@@ -4,16 +4,16 @@ In this exercise, you will be given a general description of a meetup date and t
 
 Examples of general descriptions are:
 
-- First Monday of January 2022
-- Third Tuesday of August 2021
+- 1st Monday of January 2022
+- 3rd Tuesday of August 2021
 - Teenth Wednesday of May 2022
 - Teenth Sunday of July 2021
 - Last Thursday of November 2021
 
-The descriptors you are expected to process are: `first`, `second`, `third`, `fourth`, `fifth`, `last`, `teenth`.
+The descriptors you are expected to process are: `1st`, `2nd`, `3rd`, `4th`, `5th`, `last`, `teenth`.
 
 Note that descriptor `teenth` is a made-up word.
 There are exactly seven numbered days in a month that end with "teenth" ("thirteenth" to "nineteenth").
 Therefore, it is guaranteed that each day of the week (Monday, Tuesday, ...) will have exactly one numbered day ending with "teenth" each month.
 
-For example, if given "First Monday of January 2022", the correct meetup date is January 3, 2022.
+For example, if given "1st Monday of January 2022", the correct meetup date is January 3, 2022.


### PR DESCRIPTION
resolves #3005
instructions.md specifies the week descriptors to be first, second, third, fourth and fifth.  The code in meetup_test.py is using 1st, 2nd, 3rd, 4th and 5th. Changing instructions.md preserves the previously submitted solutions.